### PR TITLE
Remove whitespace from string before parsing to enum

### DIFF
--- a/source/DD4T.ViewModels/Attributes.cs
+++ b/source/DD4T.ViewModels/Attributes.cs
@@ -415,7 +415,8 @@ namespace DD4T.ViewModels.Attributes
     /// Field that is parsed into an Enum. Must be a Text field (not Keyword).
     /// </summary>
     public class EnumFieldAttribute : FieldAttributeBase
-    {  
+    {
+        public bool RemoveWhitespace { get; set; }
         public override IEnumerable GetFieldValues(IField field, IModelProperty property, ITemplate template, IViewModelFactory factory)
         {
             var result = new List<object>();
@@ -443,7 +444,8 @@ namespace DD4T.ViewModels.Attributes
             {
                 try
                 {
-                    parsedEnum = Enum.Parse(enumType, value.ToString());
+                    string valueToBeParsed = RemoveWhitespace ? RemoveWhitespaceInsideString(value.ToString()) : value.ToString();
+                    parsedEnum = Enum.Parse(enumType, valueToBeParsed);
                     result = true;
                 }
                 catch (Exception)
@@ -452,6 +454,13 @@ namespace DD4T.ViewModels.Attributes
                 }
             }
             return result;
+        }
+
+        private string RemoveWhitespaceInsideString(string input)
+        {
+            return new string(input.ToCharArray()
+                .Where(c => !Char.IsWhiteSpace(c))
+                .ToArray());
         }
     }
 


### PR DESCRIPTION
This is related to #101, my main reason I created #101 is to be able to use a normal string (ie `United States` instead of `UnitedStates`) in drop-downs but still be able to get them as enums in .NET. Could this be something interesting? I still can't run the project on my computer though.