### PR TITLE
Fix for NestedFieldAttributes when using IComponent fields

### DIFF
--- a/source/DD4T.ViewModels/AttributesBase.cs
+++ b/source/DD4T.ViewModels/AttributesBase.cs
@@ -104,6 +104,10 @@ namespace DD4T.ViewModels.Attributes
                 {
                     fields = (modelData as IComponentPresentation).Component.Fields;
                 }
+                else if (modelData is IComponent)
+                {
+                    fields = (modelData as IComponent).Fields;
+                }
                 else if (modelData is IEmbeddedFields)
                 {
                     fields = (modelData as IEmbeddedFields).Fields;


### PR DESCRIPTION
This will address issue #104 by allowing IViewModelFactory.BuildViewModel<T>(IComponent) to success in deserializing properties with NestedFieldAttributes.